### PR TITLE
Add the `excludes` kwarg to walk() to supplement gitignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ of paths to results:
 Install
 -------
 
-trailrunner requires Python 3.6 or newer. You can install it from PyPI:
+trailrunner requires Python 3.7 or newer. You can install it from PyPI:
 
 ```shell-session
 $ pip install trailrunner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://github.com/jreese/trailrunner"
 requires = ["pathspec>=0.8.1"]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/trailrunner/core.py
+++ b/trailrunner/core.py
@@ -14,7 +14,7 @@ T = TypeVar("T")
 Excludes = Optional[List[str]]
 
 
-EXECUTOR = None  # deprecated, unused
+EXECUTOR = None  # deprecated, will be removed by 2.0
 
 INCLUDE_PATTERN: str = r".+\.pyi?$"
 """
@@ -128,6 +128,8 @@ class Trailrunner:
         """
         Default executor factory using a ProcessPoolExecutor.
         """
+        if EXECUTOR:  # deprecated
+            return EXECUTOR()
         if sys.version_info < (3, 7):  # pragma: nocover
             return ProcessPoolExecutor()
         return ProcessPoolExecutor(mp_context=self.context)

--- a/trailrunner/core.py
+++ b/trailrunner/core.py
@@ -153,9 +153,13 @@ class Trailrunner:
 
         def gen(children: Iterable[Path]) -> Iterator[Path]:
             for child in children:
-
                 if ignore.match_file(child):
                     continue
+
+                if child.is_absolute():
+                    relative = child.relative_to(root)
+                    if ignore.match_file(relative):
+                        continue
 
                 if child.is_file() and include.match_file(child):
                     yield child

--- a/trailrunner/core.py
+++ b/trailrunner/core.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license
 
 import multiprocessing
-import sys
 from concurrent.futures import ProcessPoolExecutor, Executor
 from pathlib import Path
 from typing import Iterable, Iterator, Callable, TypeVar, List, Dict, Optional
@@ -130,8 +129,6 @@ class Trailrunner:
         """
         if EXECUTOR:  # deprecated
             return EXECUTOR()
-        if sys.version_info < (3, 7):  # pragma: nocover
-            return ProcessPoolExecutor()
         return ProcessPoolExecutor(mp_context=self.context)
 
     def walk(self, path: Path, *, excludes: Excludes = None) -> Iterator[Path]:

--- a/trailrunner/core.py
+++ b/trailrunner/core.py
@@ -196,7 +196,7 @@ class Trailrunner:
         """
         all_paths: List[Path] = []
         for path in paths:
-            all_paths.extend(self.walk(path))
+            all_paths.extend(self.walk(path, excludes=excludes))
 
         return self.run(all_paths, func)
 

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -191,6 +191,14 @@ class CoreTest(TestCase):
             ]
             self.assertListEqual(expected, result)
 
+        with self.subTest("absolute subdir no gitignore with excludes"):
+            result = sorted(core.walk(self.td / "foo", excludes=["b.py"]))
+            expected = [
+                self.td / "foo" / "a.py",
+                self.td / "foo" / "bar" / "c.pyi",
+            ]
+            self.assertListEqual(expected, result)
+
         with self.subTest("local root no gitignore"):
             with cd(self.td):
                 result = sorted(core.walk(Path(".")))
@@ -213,6 +221,14 @@ class CoreTest(TestCase):
                 ]
                 self.assertListEqual(expected, result)
 
+        with self.subTest("local subdir no gitignore with excludes"):
+            with cd(self.td):
+                result = sorted(core.walk(Path("foo"), excludes=["foo/bar/"]))
+                expected = [
+                    Path("foo") / "a.py",
+                ]
+                self.assertListEqual(expected, result)
+
         (self.td / ".gitignore").write_text("vendor/\n*.pyi")
 
         with self.subTest("absolute root with gitignore"):
@@ -228,6 +244,13 @@ class CoreTest(TestCase):
             result = sorted(core.walk(self.td / "foo"))
             expected = [
                 self.td / "foo" / "a.py",
+                self.td / "foo" / "bar" / "b.py",
+            ]
+            self.assertListEqual(expected, result)
+
+        with self.subTest("absolute subdir with gitignore and excludes"):
+            result = sorted(core.walk(self.td / "foo", excludes=["a.py"]))
+            expected = [
                 self.td / "foo" / "bar" / "b.py",
             ]
             self.assertListEqual(expected, result)

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -28,17 +28,16 @@ def cd(path: Path) -> Iterator[None]:
         os.chdir(cwd)
 
 
+@patch.object(core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
     maxDiff = None
 
     def setUp(self) -> None:
-        core.Trailrunner.DEFAULT_EXECUTOR = ThreadPoolExecutor
         self.temp_dir = TemporaryDirectory()
         self.td = Path(self.temp_dir.name).resolve()
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
-        core.Trailrunner.DEFAULT_EXECUTOR = None
 
     def test_executor(self) -> None:
         def spawn_factory() -> ProcessPoolExecutor:

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -198,10 +198,9 @@ class CoreTest(TestCase):
             self.assertListEqual(expected, result)
 
         with self.subTest("absolute subdir no gitignore with excludes"):
-            result = sorted(core.walk(self.td / "foo", excludes=["b.py"]))
+            result = sorted(core.walk(self.td / "foo", excludes=["foo/bar/", "b.py"]))
             expected = [
                 self.td / "foo" / "a.py",
-                self.td / "foo" / "bar" / "c.pyi",
             ]
             self.assertListEqual(expected, result)
 

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Iterator
 from unittest import TestCase
+from unittest.mock import patch
 
 from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
@@ -72,6 +73,11 @@ class CoreTest(TestCase):
             core.Trailrunner.DEFAULT_EXECUTOR = None
             with self.assertRaisesRegex(AttributeError, "Can't pickle local object"):
                 core.Trailrunner().run(inputs, foo)
+
+        with self.subTest("deprecated EXECUTOR"):
+            with patch("trailrunner.core.EXECUTOR") as mock_exe:
+                core.Trailrunner().run(inputs, foo)
+                mock_exe.assert_called_with()
 
     def test_project_root_empty(self) -> None:
         result = core.project_root(self.td)

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -3,7 +3,6 @@
 
 import multiprocessing
 import os
-import sys
 from concurrent.futures.process import ProcessPoolExecutor
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -60,13 +59,12 @@ class CoreTest(TestCase):
             )
             self.assertEqual(expected, result)
 
-        if sys.version_info >= (3, 7):
-            with self.subTest("explicit spawn factory"):
-                parent = os.getpid()
-                results = core.Trailrunner(executor_factory=spawn_factory).run(
-                    inputs, getpid
-                )
-                self.assertNotEqual(expected, results)
+        with self.subTest("explicit spawn factory"):
+            parent = os.getpid()
+            results = core.Trailrunner(executor_factory=spawn_factory).run(
+                inputs, getpid
+            )
+            self.assertNotEqual(expected, results)
 
         with self.subTest("patched thread pool"):
             result = core.Trailrunner().run(inputs, getpid)


### PR DESCRIPTION
This would allow projects like µfmt to pass an extra list of excludes. trailrunner will then use this in addition to the project's `.gitignore` to filter out files that get returned from `walk()`.