### PR TITLE
Re-enable 3.6 support using futures3 backport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ of paths to results:
 Install
 -------
 
-trailrunner requires Python 3.7 or newer. You can install it from PyPI:
+trailrunner requires Python 3.6 or newer. You can install it from PyPI:
 
 ```shell-session
 $ pip install trailrunner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://github.com/jreese/trailrunner"
-requires = ["pathspec>=0.8.1"]
-requires-python = ">=3.7"
+requires = ["pathspec>=0.8.1", "futures3>=1.0.0; python_version < '3.7'"]
+requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ coverage==5.5
 flit==3.2.0
 flake8==3.9.0
 flake8-bugbear==21.4.3
+futures3==1.0.0; python_version < '3.7'
 mypy==0.812
 sphinx==3.5.3
 ufmt==1.2

--- a/trailrunner/compat.py
+++ b/trailrunner/compat.py
@@ -1,0 +1,21 @@
+# Copyright 2021 John Reese
+# Licensed under the MIT license
+
+import sys
+import typing
+
+if sys.version_info < (3, 7):  # pragma: no cover
+    if typing.TYPE_CHECKING:
+        # futures3 does not have stubs
+        from concurrent.futures import Executor
+
+        class ProcessPoolExecutor(Executor):
+            def __init__(self, **kwargs: typing.Any) -> None:
+                pass
+
+    else:
+        from futures3.process import ProcessPoolExecutor
+else:  # pragma: no cover
+    from concurrent.futures import ProcessPoolExecutor
+
+__all__ = ["ProcessPoolExecutor"]

--- a/trailrunner/core.py
+++ b/trailrunner/core.py
@@ -2,12 +2,14 @@
 # Licensed under the MIT license
 
 import multiprocessing
-from concurrent.futures import ProcessPoolExecutor, Executor
+from concurrent.futures import Executor
 from pathlib import Path
 from typing import Iterable, Iterator, Callable, TypeVar, List, Dict, Optional
 
 from pathspec import PathSpec, Pattern, RegexPattern
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
+
+from .compat import ProcessPoolExecutor
 
 T = TypeVar("T")
 Excludes = Optional[List[str]]

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -3,7 +3,6 @@
 
 import multiprocessing
 import os
-from concurrent.futures.process import ProcessPoolExecutor
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,6 +15,7 @@ from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from trailrunner import core
+from ..compat import ProcessPoolExecutor
 
 
 @contextmanager


### PR DESCRIPTION
This was a lot easier than I thought once I found the backport.  I do wish the naming of such things was more standardized.  Tests pass, and it's able to format itself under 3.6.