### PR TITLE
Add `concurrency` parameter to `Trailrunner` class

### DIFF
--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Generator, Iterator
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
@@ -95,7 +95,6 @@ class CoreTest(TestCase):
                     tr = core.Trailrunner(concurrency=level)
                     tr.walk_and_run([self.td], Path)
                     pool_mock.assert_called_with(expected_param, mp_context=tr.context)
-
 
     def test_project_root_empty(self) -> None:
         result = core.project_root(self.td)

--- a/trailrunner/tests/core.py
+++ b/trailrunner/tests/core.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Generator, Iterator
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
@@ -80,7 +80,7 @@ class CoreTest(TestCase):
                         mock_exe.assert_called_with()
 
     @patch("trailrunner.core.ProcessPoolExecutor")
-    def test_concurrency(self, pool_mock) -> None:
+    def test_concurrency(self, pool_mock: Mock) -> None:
         (self.td / "foo.py").write_text("\n")
         (self.td / "bar.py").write_text("\n")
 
@@ -93,7 +93,7 @@ class CoreTest(TestCase):
             ]:
                 with self.subTest(level):
                     tr = core.Trailrunner(concurrency=level)
-                    tr.walk_and_run([self.td], Path.resolve)
+                    tr.walk_and_run([self.td], Path)
                     pool_mock.assert_called_with(expected_param, mp_context=tr.context)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81

This allows specifically a non-default level of concurrency, for CLIs
with a `-j` option, or for workloads that benefit from higher or lower
levels of child process concurrency.

Fixes #74 